### PR TITLE
refactor: change class method naming style (#1)

### DIFF
--- a/packages/trad/index.js
+++ b/packages/trad/index.js
@@ -694,7 +694,7 @@ class CMethod extends CFunction {
   }
 
   get cName() {
-    const name = `${this.parent.className}_${capitalize(this.methodName)}`
+    const name = `${this.parent.className}_${this.isStatic ? '_' : ''}${capitalize(this.methodName)}`
 
     if (this.parent.useNamespaceForMethods && this.parent.namespace) {
       return `${this.parent.namespace}_${name}`


### PR DESCRIPTION

## Purpose
Solve issue #1.

## Change
I used the solutioin 3 (https://github.com/lc-soft/trad/issues/1#issuecomment-502413426).
If function is static, add an underscore(`_`) after the class name.

## Test
1. Build example
```bash
$ npm run build:example
```
2. View app.jsx.c
The naming style of static functions has been changed to double underscores.
Before:
![before](https://user-images.githubusercontent.com/9170826/61608682-8f3d3f00-ac8e-11e9-8f6b-6b6d726bf0c2.png)
After:
![after](https://user-images.githubusercontent.com/9170826/61608686-92382f80-ac8e-11e9-9d7a-8a3608177b6b.png)
