### PR TITLE
feat: add command-line interface (#3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "acorn": "^6.1.1",
     "acorn-jsx": "^5.0.1",
+    "commander": "^2.20.0",
     "merge": "^1.2.1"
   },
   "devDependencies": {

--- a/packages/trad-cli/tradc.js
+++ b/packages/trad-cli/tradc.js
@@ -1,7 +1,18 @@
 const { compile } = require('./index')
+const program = require('commander')
+const pjson = require('../../package.json')
 
-// FIXME: Add command-line interfaces
+program
+  .version(pjson.version)
+  .arguments('[file]')
+  .description('Compile [file] to C source file.')
+  .action(file => sourceFile = file)
 
-if (process.argv.length === 3) {
-  compile(process.argv[2])
+program.parse(process.argv)
+
+if (typeof sourceFile === 'undefined') {
+  console.error('no source file given.\n')
+  program.help()
 }
+
+compile(sourceFile)

--- a/packages/trad-cli/tradc.js
+++ b/packages/trad-cli/tradc.js
@@ -1,9 +1,9 @@
 const { compile } = require('./index')
 const program = require('commander')
-const pjson = require('../../package.json')
+const version = require('../../package.json').version
 
 program
-  .version(pjson.version)
+  .version(version)
   .arguments('[file]')
   .description('Compile [file] to C source file.')
   .action(file => sourceFile = file)


### PR DESCRIPTION
## Purpose
Solve issue #3.

## Changes
- Add Commander.js(https://github.com/tj/commander.js) package
- Implement command-line interface
  A user needs to specify the source file to compile.
  If no argument is specified, the process exits after displaying error information and usage information.

## Test
List of operation checked commands.

- `node ./bin/tradc --help`
Display usage information.
![display_help](https://user-images.githubusercontent.com/9170826/61628949-97ad6e00-acbe-11e9-8ac6-683aa3db1993.png)

- `node ./bin/tradc --version`
Display version. Version information is got from `package.json`.
![display_version](https://user-images.githubusercontent.com/9170826/61628951-9aa85e80-acbe-11e9-83ec-a57056dba7af.png)

- `node ./bin/tradc`
Display error information and usage information.
![display_error](https://user-images.githubusercontent.com/9170826/61628961-a005a900-acbe-11e9-8cfd-040b2d30612e.png)

- `node ./bin/tradc example/src/app.jsx`
No change.
![compile](https://user-images.githubusercontent.com/9170826/61628978-a85de400-acbe-11e9-82b2-c77195ddd432.png)

- `npm run build:example`
No change.
Same as above.
